### PR TITLE
Fix default band selection

### DIFF
--- a/geedl/gee/data_loader.py
+++ b/geedl/gee/data_loader.py
@@ -28,7 +28,11 @@ class DataLoader:
         """
         Process an image by selecting bands and applying normalization.
         """
-        img = img.select(ORIGINAL_BANDS[series], RENAMED_BANDS[series]).select(self.bands)
+        img = img.select(ORIGINAL_BANDS[series], RENAMED_BANDS[series])
+
+        # If user specifies bands, select them; otherwise keep all renamed bands
+        if self.bands:
+            img = img.select(self.bands)
         
         # Apply normalization
         if self.normalize:


### PR DESCRIPTION
## Summary
- handle the `bands=None` case in `DataLoader.process_image`

## Testing
- `python -m py_compile geedl/gee/data_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6847909b9070832d8ff6b9b24204feb0